### PR TITLE
Change Object serialization api from  int obj_serialize(cord_obj_t *o…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(cord)
-
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -ggdb")
 add_subdirectory(src)
 add_subdirectory(tests)
 add_subdirectory(examples)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -8,6 +8,6 @@ set(Libraries
     curl
     cord
 )
-
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -ggdb")
 add_executable(ping_pong ping_pong.c)
 target_link_libraries(ping_pong PUBLIC ${Libraries})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -ggdb")
 set(Sources
     cord.c
     discord.c

--- a/src/cord.c
+++ b/src/cord.c
@@ -1,21 +1,22 @@
 #include "cord.h"
 #include "discord.h"
+#include "error.h"
 #include <uwsc/uwsc.h>
 
 cord_t *cord_create(void) {
 	cord_t *c = malloc(sizeof(cord_t));
-	c->disc = discord_create();	
+	c->client = discord_create();	
 	return c;
 }
 
 void cord_connect(cord_t *c, const char *url) {
-	discord_connect(c->disc, url);
+	discord_connect(c->client, url);
 }
 
 void cord_destroy(cord_t *c) {
 	if (c) {
-		if (c->disc) {
-			discord_destroy(c->disc);
+		if (c->client) {
+			discord_destroy(c->client);
 		}
 		free(c);
 	}
@@ -23,5 +24,5 @@ void cord_destroy(cord_t *c) {
 
 
 void cord_on_message(cord_t *c, on_msg_cb func) {
-	c->disc->on_message_callback = func;
+	c->client->on_message_callback = func;
 }

--- a/src/cord.h
+++ b/src/cord.h
@@ -8,7 +8,8 @@ typedef struct cord_t cord_t;
 typedef void (*on_msg_cb)(discord_t *c, cord_message_t *msg);
 typedef struct cord_t {
 	// should be the first field in the struct	
-	discord_t *disc;
+	discord_t *client;
+	
 	on_msg_cb msg_cb;
 } cord_t;
 

--- a/src/error.h
+++ b/src/error.h
@@ -2,7 +2,7 @@
 #define ERROR_H
 
 // Library's API return values
-typedef enum cord_status {
+typedef enum cord_err {
     // Success
     CORD_OK = 0,
 
@@ -15,7 +15,7 @@ typedef enum cord_status {
     ERR_MSG_SERIALIZATION,
 
     ERR_COUNT
-} cord_status;
+} cord_err;
 
 char *cord_error(int type);
 

--- a/src/types.h
+++ b/src/types.h
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <jansson.h>
 
+#include "error.h"
 #include "sds.h"
 
 // https://discord.com/developers/docs/resources/user#user-object
@@ -27,22 +28,6 @@ int cord_user_init(cord_user_t *user);
 int cord_user_serialize(cord_user_t *author, json_t *data);
 void cord_user_free(cord_user_t *user);
 
-// https://discord.com/developers/docs/resources/guild#guild-member-object
-typedef struct cord_guild_member_t {
-    cord_user_t *user;
-    sds nick;
-    sds *roles; // array
-    sds joined_at;
-    sds premium_since;
-    bool deaf;
-    bool mute;
-    bool pending;    
-} cord_guild_member_t;
-
-int cord_guild_member_init(cord_guild_member_t *member);
-int cord_guild_member_serialize(cord_guild_member_t *member, json_t *data);
-void cord_guild_member_free(cord_guild_member_t *member);
-
 // https://discord.com/developers/docs/topics/permissions#role-object
 typedef struct cord_role_t {
     sds id;
@@ -59,6 +44,23 @@ typedef struct cord_role_t {
 int cord_role_init(cord_role_t *role);
 int cord_role_serialize(cord_role_t *role, json_t *data);
 void cord_role_free(cord_role_t *role);
+
+// https://discord.com/developers/docs/resources/guild#guild-member-object
+typedef struct cord_guild_member_t {
+    cord_user_t *user;
+    sds nick;
+    cord_role_t *roles[64];
+	int _roles_count;
+	sds joined_at;
+    sds premium_since;
+    bool deaf;
+    bool mute;
+    bool pending;    
+} cord_guild_member_t;
+
+int cord_guild_member_init(cord_guild_member_t *member);
+int cord_guild_member_serialize(cord_guild_member_t *member, json_t *data);
+void cord_guild_member_free(cord_guild_member_t *member);
 
 // https://discord.com/developers/docs/resources/channel#channel-mention-object
 typedef struct cord_channel_mention_t {
@@ -265,7 +267,7 @@ int cord_message_sticker_init(cord_message_sticker_t *ms);
 int cord_message_sticker_serialize(cord_message_sticker_t *ms, json_t *data);
 void cord_message_sticker_free(cord_message_sticker_t *ms);
 
-#define MAX_ARRAY 128
+#define MAX_ARRAY 4
 // (Message) - https://discord.com/developers/docs/resources/channel#message-object
 typedef struct cord_message_t {
 	sds id;
@@ -313,8 +315,8 @@ typedef struct cord_message_t {
 	struct cord_message_t *referenced_message;
 } cord_message_t;
 
-int cord_message_init(cord_message_t *msg);
-int cord_message_serialize(cord_message_t *msg, json_t *data);
+void cord_message_init(cord_message_t *msg);
+cord_message_t *cord_message_serialize(json_t *data, cord_err *err);
 void cord_message_free(cord_message_t *msg);
 
 typedef struct cord_guild_t {


### PR DESCRIPTION
…bj, json *data) to cord_obj_t *obj_serialize(json *data, cord_err *err).

This prevents the heap corruption bug that we've been running into when calling malloc to the passed object.